### PR TITLE
Removing warning of bot ignoring its own message

### DIFF
--- a/bots/derek-bot/derek_bot.py
+++ b/bots/derek-bot/derek_bot.py
@@ -508,7 +508,6 @@ class DerekBot(commands.Bot):
 
         # Returning if we are responding/speaking the bot's message
         if message.author == self.user:
-            logging.warning("Prevented the bot from talking to itself")
             return
         
         # Chat processing. First ignoring DMs, then continuing processing


### PR DESCRIPTION
This is a preventative measure, we don't need to know each time it avoids responding to itself. This will suffice