### PR TITLE
Removing db item creation time functions

### DIFF
--- a/bots/derek-bot/ai_tools/memory_tools.py
+++ b/bots/derek-bot/ai_tools/memory_tools.py
@@ -1,5 +1,4 @@
 from shared.data_manager import DataManager
-from shared.time_utils import get_est_iso_date
 import logging
 from discord import Member
 
@@ -19,7 +18,6 @@ class MemoryTools:
             table_name="chat_memories",
             json_data={
                 "memory": memory_string,
-                "created": get_est_iso_date(),
                 "added_by": None
             }
         )

--- a/bots/derek-bot/cogs/ai_cog.py
+++ b/bots/derek-bot/cogs/ai_cog.py
@@ -2,7 +2,6 @@ from discord.ext import commands
 from discord import app_commands, Interaction
 import random
 import logging
-from shared.time_utils import get_est_iso_date
 
 from shared.data_manager import DataManager, ListIndexOutOfBounds
 from shared.DiscordList import DiscordList
@@ -34,7 +33,7 @@ class AICog(commands.Cog):
             self.data_manager.ensure_user_exists(interaction.user)
             successfully_added = self.data_manager.add_table_data(
                 table_name="chat_memories",
-                json_data={"memory": memory, "created": get_est_iso_date(), "added_by": interaction.user.id}
+                json_data={"memory": memory, "added_by": interaction.user.id}
             )
 
             if successfully_added:

--- a/bots/derek-bot/cogs/misc_cog.py
+++ b/bots/derek-bot/cogs/misc_cog.py
@@ -4,7 +4,6 @@ import logging
 
 from shared.data_manager import DataManager, ListIndexOutOfBounds
 from shared.DiscordList import DiscordList
-from shared.time_utils import get_est_iso_date
 import random
 
 
@@ -91,7 +90,7 @@ class MiscGroupCog(commands.Cog):
 
         successfully_added = self.data_manager.add_table_data(
             table_name="random_user_nicknames",
-            json_data={"nickname": nickname, "created": get_est_iso_date(), "added_by": interaction.user.id}
+            json_data={"nickname": nickname, "added_by": interaction.user.id}
         )
 
         if successfully_added:

--- a/bots/derek-bot/derek_bot.py
+++ b/bots/derek-bot/derek_bot.py
@@ -84,7 +84,7 @@ db_manager = DataManager(
         },
         "nickname_shuffle_tracks": {
             "select": "*",
-            "order_by": {"column": "created_at", "ascending": False}
+            "order_by": {"column": "created", "ascending": False}
         }
     }
 )
@@ -403,7 +403,7 @@ class DerekBot(commands.Bot):
 
         recent_shuffle = False
         for track in self.data_manager.data.get("nickname_shuffle_tracks"):
-            created_at = track.get("created_at")
+            created_at = track.get("created")
             if created_at:
                 created_at_dt = datetime.fromisoformat(created_at)
 

--- a/shared/time_utils.py
+++ b/shared/time_utils.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 import pytz
 
-
-# NOTE: This should be depreciated in the future in favor of using the default system time rather than set EST
 def get_est_iso_date():
     """
+    DEPRECIATED: Use DB time. This is only being preserved incase future time functions are needed
     Gets the current date and time for EST in iso format
     
     :return: ISO formatted date and time in EST


### PR DESCRIPTION
We can use the time setting built into the db, so lets just so that. It's easier