### PR TITLE
Clean YouTube playlist param from song URLs

### DIFF
--- a/shared/track_downloader/utils.py
+++ b/shared/track_downloader/utils.py
@@ -16,7 +16,8 @@ def parse_url_info(url):
         "query": parse_qs(parsed.query),
         "path": parsed.path,
         "netloc": parsed.netloc,
-        "scheme": parsed.scheme
+        "scheme": parsed.scheme,
+        "parsed": parsed
     }
 
 


### PR DESCRIPTION
When both 'song' and 'playlist' are detected for YouTube links, the 'list' query parameter is removed to ensure the URL is treated as a song. Also, parse_url_info now returns the full parsed URL object for easier manipulation.