### PR TITLE
Simplify song queueing logic and enforce high priority

### DIFF
--- a/bots/derpods/cogs/music_command_cog.py
+++ b/bots/derpods/cogs/music_command_cog.py
@@ -66,8 +66,7 @@ class MusicCommandCog(commands.Cog):
         try:
             song_request = await self.music_service.download_and_queue_song_from_url(
                 song_url,
-                interaction.user,
-                high_priority=True
+                interaction.user
             )
             logging.info(f"User {interaction.user.name} requested to add song: {song_url}")
             await interaction.followup.send(f"Added **{song_request.title}** to the queue.")
@@ -106,8 +105,7 @@ class MusicCommandCog(commands.Cog):
         try:
             song_request = await self.music_service.download_and_queue_song_from_query(
                 search_query,
-                interaction.user,
-                high_priority=True
+                interaction.user
             )
             logging.info(f"User {interaction.user.name} requested to search song: {search_query}")
             await interaction.followup.send(f"Added **{song_request.title}** to the queue.")

--- a/shared/music_service.py
+++ b/shared/music_service.py
@@ -33,8 +33,7 @@ class MusicService:
     async def download_and_queue_song_from_url(
             self,
             song_url: str,
-            user: Member,
-            high_priority: bool = None
+            user: Member
     ) -> SongRequest:
         """
         Downloads a song using the SongDownloader and adds it to the VCAudioManager's queue.
@@ -49,23 +48,14 @@ class MusicService:
         logging.info(f"Downloaded song: {song_request.title}")
 
         # Add the downloaded song to the audio manager's queue
-        if high_priority is not None:
-            await self.audio_manager.add_to_queue(
-                song_request.file_path,
-                song_request.content_duration,
-                user.voice.channel,
-                high_priority=high_priority,
-                audio_name=song_request.title,
-                added_by=user.display_name
-            )
-        else:
-            await self.audio_manager.add_to_queue(
-                song_request.file_path,
-                song_request.content_duration,
-                user.voice.channel,
-                audio_name=song_request.title,
-                added_by=user.display_name
-            )
+        await self.audio_manager.add_to_queue(
+            song_request.file_path,
+            song_request.content_duration,
+            user.voice.channel,
+            high_priority=True,
+            audio_name=song_request.title,
+            added_by=user.display_name
+        )
         logging.info(f"Added song to queue: {song_request.title}")
 
         return song_request
@@ -73,8 +63,7 @@ class MusicService:
     async def download_and_queue_song_from_query(
             self,
             search_query: str,
-            user: Member,
-            high_priority: bool = None
+            user: Member
     ) -> SongRequest:
         """
         Downloads a song using a search query and adds it to the VCAudioManager's queue.
@@ -89,23 +78,14 @@ class MusicService:
         logging.info(f"Downloaded song from query '{search_query}': {song_request.title}")
 
         # Add the downloaded song to the audio manager's queue
-        if high_priority is not None:
-            await self.audio_manager.add_to_queue(
-                song_request.file_path,
-                song_request.content_duration,
-                user.voice.channel,
-                high_priority=high_priority,
-                audio_name=song_request.title,
-                added_by=user.display_name
-            )
-        else:
-            await self.audio_manager.add_to_queue(
-                song_request.file_path,
-                song_request.content_duration,
-                user.voice.channel,
-                audio_name=song_request.title,
-                added_by=user.display_name
-            )
+        await self.audio_manager.add_to_queue(
+            song_request.file_path,
+            song_request.content_duration,
+            user.voice.channel,
+            high_priority=True,
+            audio_name=song_request.title,
+            added_by=user.display_name
+        )
         logging.info(f"Added song to queue: {song_request.title}")
 
         return song_request


### PR DESCRIPTION
Removed the optional high_priority parameter from song queueing methods and always set high_priority to True when adding songs to the queue. This streamlines the code and ensures all queued songs are treated as high priority.