### PR TITLE
Add bot presence and permission checks before audio playback

### DIFF
--- a/shared/VCAudioManager.py
+++ b/shared/VCAudioManager.py
@@ -122,6 +122,24 @@ class VCAudioManager:
                 self.current_audio_item = self.queue.pop(0)
 
             try:
+                # Ensure the bot is in the guild
+                bot_member = self.current_audio_item.voice_channel.guild.me
+                if bot_member is None:
+                    logging.error(
+                        f"Bot is not a member of guild: {self.current_audio_item.voice_channel.guild.name}"
+                    )
+                    continue  # Skip to next item
+                
+                # Check permissions for bot to connect and speak in the voice channel
+                perms = self.current_audio_item.voice_channel.permissions_for(bot_member)
+                if not perms.connect or not perms.speak:
+                    logging.error(
+                        f"Missing permissions to join or speak in voice channel "
+                        f"({self.current_audio_item.voice_channel.name}) "
+                        f"in guild ({self.current_audio_item.voice_channel.guild.name})"
+                    )
+                    continue  # Skip to next item
+                
                 # Connect or move to the correct voice channel
                 if self._current_voice_channel is None or not self._current_voice_channel.is_connected():
                     try:


### PR DESCRIPTION
Introduces checks to ensure the bot is a member of the guild and has connect/speak permissions in the target voice channel before attempting to play audio. Logs errors and skips items if requirements are not met, improving reliability and error handling.