### PR TITLE
Add music.youtube.com to valid domains

### DIFF
--- a/shared/track_downloader/models.py
+++ b/shared/track_downloader/models.py
@@ -14,6 +14,7 @@ class LinkValidator:
     VALID_DOMAINS = {
         "youtube.com": "youtube",
         "youtu.be": "youtube",
+        "music.youtube.com": "youtube",
         "open.spotify.com": "spotify"
     }
     SANITIZATION_MAX_LENGTH = 120


### PR DESCRIPTION
Included 'music.youtube.com' in the VALID_DOMAINS mapping for LinkValidator to support YouTube Music links.