### PR TITLE
Add audio metadata support to Derpods bot

### DIFF
--- a/bots/derpods/derpods.py
+++ b/bots/derpods/derpods.py
@@ -105,6 +105,9 @@ class Derpods(BaseBot):
         self.llm_manager.set_tool_function_references(tool_references)
         self.llm_manager.set_tool_definitions(tool_definitions)
 
+        # Set metadata function for LLM manager
+        self.llm_manager.set_get_metadata(self.get_current_audio_metadata)
+
         # Set up command cogs
         cogs = [
             MusicCommandCog(
@@ -127,6 +130,18 @@ class Derpods(BaseBot):
         """
         await super().on_ready()
         self.song_tools.set_guild(self.guild)
+
+    def get_current_audio_metadata(self):
+        """
+        Returns metadata about the currently playing audio for the LLM.
+        """
+        current_audio = self.audio_manager.current_audio_item
+        if current_audio:
+            audio_name = current_audio.audio_name or "Unknown"
+            added_by = current_audio.added_by or "Unknown"
+            return f"Current Audio: '{audio_name}' (Recommended by: {added_by})"
+        else:
+            return "No audio is currently playing."
 
 # Starting the bot
 if __name__ == "__main__":

--- a/shared/ChatLLMManager.py
+++ b/shared/ChatLLMManager.py
@@ -422,3 +422,10 @@ class ChatLLMManager:
         """
         self.get_memories = get_memories
         logging.info("Updated get_memories function in ChatLLMManager.")
+
+    def set_get_metadata(self, get_metadata):
+        """
+        Updates the get_metadata function used by the manager.
+        """
+        self.get_metadata = get_metadata
+        logging.info("Updated get_metadata function in ChatLLMManager.")


### PR DESCRIPTION
Introduces a get_current_audio_metadata method to Derpods and registers it with ChatLLMManager via set_get_metadata. This enables the LLM manager to access metadata about the currently playing audio, improving context for music-related interactions.