### PR TITLE
Make memory table name configurable in MemoryTools

### DIFF
--- a/bots/derek-bot/ai_tools/memory_tools.py
+++ b/bots/derek-bot/ai_tools/memory_tools.py
@@ -3,8 +3,9 @@ import logging
 from discord import Member
 
 class MemoryTools:
-    def __init__(self, db_manager):
+    def __init__(self, db_manager, memory_table_name):
         self.db_manager = db_manager
+        self.memory_table_name = memory_table_name
 
     async def save_memory(self, memory_string: str, username: str):
         """
@@ -15,7 +16,7 @@ class MemoryTools:
         :return: Text stating whether the memory was saved or not
         """
         successfully_added = self.db_manager.add_table_data(
-            table_name="chat_memories",
+            table_name=self.memory_table_name,
             json_data={
                 "memory": memory_string,
                 "added_by": None
@@ -35,5 +36,5 @@ class MemoryTools:
         """
         return [
             memory["memory"]
-            for memory in self.db_manager.data.get("chat_memories", [])
+            for memory in self.db_manager.data.get(self.memory_table_name, [])
         ]

--- a/bots/derek-bot/derek_bot.py
+++ b/bots/derek-bot/derek_bot.py
@@ -115,7 +115,9 @@ gpt_system_prompt = db_manager.get_item_by_key(
 if not gpt_system_prompt:
     raise ValueError("gpt_system_prompt cannot be None. There was an issue pulling info from the DB.")
 
-memory_tools = MemoryTools(db_manager=db_manager)
+MEMORY_TABLE_NAME = "chat_memories"
+memory_tools = MemoryTools(db_manager=db_manager, memory_table_name=MEMORY_TABLE_NAME)
+
 tool_references = {
     "save_memory": memory_tools.save_memory,
     "generate_color_swatch": generate_color_swatch,


### PR DESCRIPTION
Refactored MemoryTools to accept a memory_table_name parameter instead of hardcoding 'chat_memories'. Updated derek_bot.py to pass the table name explicitly, improving flexibility for future changes or multiple memory tables.